### PR TITLE
Use erlang version of uaa_jwt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ TEST_DEPS = cowboy rabbitmq_web_dispatch rabbitmq_ct_helpers
 
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-dep_uaa_jwt = git_rmq uaa_jwt $(current_rmq_ref) $(base_rmq_ref) master
-dep_jose = hex 1.8.0
+dep_uaa_jwt = git_rmq uaa_jwt $(current_rmq_ref) $(base_rmq_ref) erlang
+dep_jose = hex 1.8.4
 
 # FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be
 # reviewed and merged.

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TEST_DEPS = cowboy rabbitmq_web_dispatch rabbitmq_ct_helpers
 
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 
-dep_uaa_jwt = git_rmq uaa_jwt $(current_rmq_ref) $(base_rmq_ref) erlang
+dep_uaa_jwt = git_rmq uaa_jwt $(current_rmq_ref) $(base_rmq_ref) master
 dep_jose = hex 1.8.4
 
 # FIXME: Use erlang.mk patched for RabbitMQ, while waiting for PRs to be

--- a/src/Elixir.RabbitMQ.CLI.Ctl.Commands.AddUaaKeyCommand.erl
+++ b/src/Elixir.RabbitMQ.CLI.Ctl.Commands.AddUaaKeyCommand.erl
@@ -49,7 +49,7 @@ validate([_], Options) ->
 validate_json(Json) ->
     case rabbit_json:try_decode(Json) of
         {ok, _} ->
-            case 'Elixir.UaaJWT':verify_signing_key(json, Json) of
+            case uaa_jwt:verify_signing_key(json, Json) of
                 ok -> ok;
                 {error, {fields_missing_for_kty, Kty}} ->
                     {validation_failure,
@@ -71,7 +71,7 @@ validate_json(Json) ->
     end.
 
 validate_pem(Pem) ->
-    case 'Elixir.UaaJWT':verify_signing_key(pem, Pem) of
+    case uaa_jwt:verify_signing_key(pem, Pem) of
         ok -> ok;
         {error, invalid_pem_string} ->
             {validation_failure, <<"Unable to read a key from the PEM string">>};
@@ -80,7 +80,7 @@ validate_pem(Pem) ->
     end.
 
 validate_pem_file(PemFile) ->
-    case 'Elixir.UaaJWT':verify_signing_key(pem_file, PemFile) of
+    case uaa_jwt:verify_signing_key(pem_file, PemFile) of
         ok -> ok;
         {error, enoent} ->
             {validation_failure, {bad_argument, <<"PEM file not found">>}};
@@ -118,7 +118,7 @@ run([Name], #{node := Node} = Options) ->
         #{pem_file := PemFile} -> {pem_file, PemFile}
     end,
     case rabbit_misc:rpc_call(Node,
-                              'Elixir.UaaJWT', add_signing_key,
+                              uaa_jwt, add_signing_key,
                               [Name, Type, Value]) of
         {ok, _Keys}  -> ok;
         {error, Err} -> {error, Err}

--- a/src/rabbit_auth_backend_uaa.erl
+++ b/src/rabbit_auth_backend_uaa.erl
@@ -94,7 +94,7 @@ validate_token_active(#{}) -> ok.
 
 -spec check_token(binary()) -> {ok, map()} | {error, term()}.
 check_token(Token) ->
-    case 'Elixir.UaaJWT':decode_and_verify(Token) of
+    case uaa_jwt:decode_and_verify(Token) of
         {error, Reason} -> {refused, {error, Reason}};
         {true, Payload} -> validate_payload(Payload);
         {false, _}      -> {refused, signature_invalid}


### PR DESCRIPTION
Using the `erlang` branch of `uaa_jwt` lib. When accepted, the `erlang` branch in `uaa_jwt` should be made master.

This change only includes switching to erlang, there can be more fixes in uaa_jwt.
