### PR TITLE
uaa_jwt is no longer a separate application

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PROJECT_DESCRIPTION = OAuth 2 and JWT-based AuthN and AuthZ backend
 
 BUILD_DEPS = rabbit_common
 DEPS = rabbit cowlib jose
-TEST_DEPS = cowboy rabbitmq_web_dispatch rabbitmq_ct_helpers amqp_client
+TEST_DEPS = cowboy rabbitmq_web_dispatch rabbitmq_ct_helpers rabbitmq_ct_client_helpers amqp_client
 
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 

--- a/README.md
+++ b/README.md
@@ -78,13 +78,14 @@ it will translate into the following configuration (in the [advanced RabbitMQ co
 [
   %% ...
   %% backend configuration
-  {rabbitmq_auth_backend_oauth2, [{resource_server_id, <<"my_rabbit_server">>}]},
-  %% UAA signing key configuration
-  {uaa_jwt, [
-    {signing_keys, #{
+  {rabbitmq_auth_backend_oauth2, [
+    {resource_server_id, <<"my_rabbit_server">>},
+    %% UAA signing key configuration
+    {uaa_jwt, [
+      {signing_keys, #{
         <<"a-key-ID">> => {map, #{<<"kty">> => <<"RSA">>,
-                                          <<"alg">> => <<"RS256">>,
-                                          <<"value">> => <<"-----BEGIN PUBLIC KEY-----
+                                  <<"alg">> => <<"RS256">>,
+                                  <<"value">> => <<"-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
 6+CKNAduCC1raLfTH7B3qjmZYm45yDl+XmgK9CNmHXkho9qvmhdksdzDVsdeDlhK
 IdcIWadhqDzdtn1hj/22iUwrhH0bd475hlKcsiZ+oy/sdgGgAzvmmTQmdMqEXqV2
@@ -93,22 +94,26 @@ B9q9KFBmo4Ahh/6+d4wM1rH9kxl0RvMAKLe+daoIHIjok8hCO4cKQQEw/ErBe4SF
 QAvkknWitpRK8KVLypEj5WKej6CF8nq30utn15FQg0JkHoqzwiCqqeen8GIPteI7
 VwIDAQAB
 -----END PUBLIC KEY-----">>}}
-        }}
-    ]}
+          }}
+      ]}
+    ]},
 ].
 ```
 
 If you are using a symmetric key, the configuration will look like this:
 
 ```erlang
-[ {rabbitmq_auth_backend_oauth2, [{resource_server_id, <<"my_rabbit_server">>}]},
-  {uaa_jwt, [
-    {signing_keys, #{
+[
+  {rabbitmq_auth_backend_oauth2, [
+    {resource_server_id, <<"my_rabbit_server">>}
+    {uaa_jwt, [
+      {signing_keys, #{
         <<"a-key-ID">> => {map, #{<<"kty">> => <<"MAC">>,
                                   <<"alg">> => <<"HS256">>,
                                   <<"value">> => <<"my_signing_key">>}}
-        }}
+      }}
     ]}
+  ]},
 ].
 ```
 

--- a/demo/rsa_keys/rabbitmq.config
+++ b/demo/rsa_keys/rabbitmq.config
@@ -1,13 +1,13 @@
-[{rabbit,
-    [{auth_backends, [rabbit_auth_backend_oauth2, rabbit_auth_backend_internal]}]},
- {rabbitmq_auth_backend_oauth2,
-    [{resource_server_id, <<"rabbitmq">>}]},
- {uaa_jwt, [
-  {default_key, <<"legacy-token-key">>},
-  {signing_keys,
-    #{
-        <<"legacy-token-key">> =>
-            {pem, <<"-----BEGIN PUBLIC KEY-----
+[
+  {rabbit, [
+    {auth_backends, [rabbit_auth_backend_oauth2, rabbit_auth_backend_internal]}
+  ]},
+  {rabbitmq_auth_backend_oauth2, [
+    {resource_server_id, <<"rabbitmq">>},
+    {uaa_jwt, [
+      {default_key, <<"legacy-token-key">>},
+      {signing_keys,
+        #{<<"legacy-token-key">> => {pem, <<"-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
 6+CKNAduCC1raLfTH7B3qjmZYm45yDl+XmgK9CNmHXkho9qvmhdksdzDVsdeDlhK
 IdcIWadhqDzdtn1hj/22iUwrhH0bd475hlKcsiZ+oy/sdgGgAzvmmTQmdMqEXqV2
@@ -16,6 +16,8 @@ B9q9KFBmo4Ahh/6+d4wM1rH9kxl0RvMAKLe+daoIHIjok8hCO4cKQQEw/ErBe4SF
 QAvkknWitpRK8KVLypEj5WKej6CF8nq30utn15FQg0JkHoqzwiCqqeen8GIPteI7
 VwIDAQAB
 -----END PUBLIC KEY-----">>}
+         }
+      }]
     }
-  }]
-}].
+  ]}
+].

--- a/demo/setup.sh
+++ b/demo/setup.sh
@@ -60,14 +60,14 @@ uaac token owner get rabbit_client rabbit_nosuper -s rabbit_secret -p rabbit_nos
 echo "Auth info for rabbit_nosuper user
 This user will have read access to uaa_vhost resources,
 which name start with some and write access to all uaa_vhost resources.
-Use access_token as a RabbitMQ username"
+Use access_token as a RabbitMQ password, the username is ignored"
 echo
 uaac context rabbit_nosuper
 echo
 
 echo "Auth info for rabbit_super user
 This user will have full access to all rabbitmq vhosts.
-Use access_token as a RabbitMQ username"
+Use access_token as a RabbitMQ password, the username is ignored"
 echo
 uaac context rabbit_super
 echo

--- a/demo/symmetric_keys/rabbitmq.config
+++ b/demo/symmetric_keys/rabbitmq.config
@@ -1,7 +1,7 @@
 [
     % Enable auth backend
     {rabbit, [
-        {auth_backends, [rabbit_auth_backend_oauth2]}
+        {auth_backends, [rabbit_auth_backend_oauth2, rabbit_auth_backend_internal]}
     ]},
 
     % Set a resource server ID. Will require all scopes to be prefixed with `rabbitmq.`

--- a/demo/symmetric_keys/rabbitmq.config
+++ b/demo/symmetric_keys/rabbitmq.config
@@ -1,17 +1,25 @@
-[{rabbit,
-    [{auth_backends, [rabbit_auth_backend_oauth2, rabbit_auth_backend_internal]}]},
- {rabbitmq_auth_backend_uaa,
-    [{resource_server_id, <<"rabbitmq">>}]},
- {uaa_jwt, [
-  {default_key, <<"legacy-token-key">>},
-  {signing_keys,
-    #{
-        <<"legacy-token-key">> =>
-            {map,
-                #{<<"kty">> => <<"MAC">>,
-                  <<"value">> => <<"rabbit_signing_key">>,
-                  <<"alg">> => <<"HS256">>}
-            }
-    }
-  }]
-}].
+[
+    % Enable auth backend
+    {rabbit, [
+        {auth_backends, [rabbit_auth_backend_oauth2]}
+    ]},
+
+    % Set a resource server ID. Will require all scopes to be prefixed with `rabbitmq.`
+    {rabbitmq_auth_backend_oauth2, [
+        {resource_server_id, <<"rabbitmq">>},
+        % Set up a legacy signing key
+        {uaa_jwt, [
+            {default_key, <<"legacy-token-key">>},
+            {signing_keys, #{
+                <<"legacy-token-key">> =>
+                    {map, #{
+                        <<"alg">> => <<"HS256">>,
+                        <<"value">> => <<"rabbit_signing_key">>,
+                        <<"kty">> => <<"MAC">>,
+                        <<"use">> => <<"sig">>}
+                    } % end map
+                } % end signing_keys map
+            } % end signing_keys
+        ]} % end uaa_jwt
+    ]} % end rabbitmq_auth_backend_oauth2
+].

--- a/src/rabbit_auth_backend_oauth2.erl
+++ b/src/rabbit_auth_backend_oauth2.erl
@@ -114,8 +114,8 @@ check_token(Token) ->
     end.
 
 validate_payload(#{<<"scope">> := _Scope, <<"aud">> := _Aud} = DecodedToken) ->
-    ResourceServerId = rabbit_data_coercion:to_binary(application:get_env(rabbitmq_auth_backend_oauth2,
-                                                                          resource_server_id, <<>>)),
+    ResourceServerEnv = application:get_env(rabbitmq_auth_backend_oauth2, resource_server_id, <<>>),
+    ResourceServerId = rabbit_data_coercion:to_binary(ResourceServerEnv),
     validate_payload(DecodedToken, ResourceServerId).
 
 validate_payload(#{<<"scope">> := Scope, <<"aud">> := Aud} = DecodedToken, ResourceServerId) ->

--- a/src/uaa_jwt_jwk.erl
+++ b/src/uaa_jwt_jwk.erl
@@ -69,11 +69,10 @@ fix_alg(#{<<"alg">> := Alg} = Key) ->
 fix_alg(#{} = Key) -> Key.
 
 uaa_algs() ->
-    application:get_env(uaa_jwt_decoder, uaa_algs,
-                        #{
-                          <<"HMACSHA256">> => <<"HS256">>,
-                          <<"HMACSHA384">> => <<"HS384">>,
-                          <<"HMACSHA512">> => <<"HS512">>,
-                          <<"SHA256withRSA">> => <<"RS256">>,
-                          <<"SHA512withRSA">> => <<"RS512">>
-                        }).
+    UaaEnv = application:get_env(rabbitmq_auth_backend_oauth2, uaa_jwt_decoder, []),
+    DefaultAlgs = #{<<"HMACSHA256">> => <<"HS256">>,
+                    <<"HMACSHA384">> => <<"HS384">>,
+                    <<"HMACSHA512">> => <<"HS512">>,
+                    <<"SHA256withRSA">> => <<"RS256">>,
+                    <<"SHA512withRSA">> => <<"RS512">>},
+    proplists:get_value(uaa_algs, UaaEnv, DefaultAlgs).

--- a/src/uaa_jwt_jwt.erl
+++ b/src/uaa_jwt_jwt.erl
@@ -35,7 +35,8 @@ get_key_id(Token) ->
 
 
 get_default_key() ->
-    case application:get_env(uaa_jwt, default_key, undefined) of
+    UaaEnv = application:get_env(rabbitmq_auth_backend_oauth2, uaa_jwt, []),
+    case proplists:get_value(default_key, UaaEnv, undefined) of
         undefined -> {error, no_key};
         Val       -> {ok, Val}
     end.

--- a/test/system_SUITE.erl
+++ b/test/system_SUITE.erl
@@ -106,8 +106,9 @@ preconfigure_node(Config) ->
     ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
                                       [rabbit, auth_backends, [rabbit_auth_backend_oauth2]]),
     Jwk   = ?UTIL_MOD:fixture_jwk(),
+    UaaEnv = [{signing_keys, #{<<"token-key">> => {map, Jwk}}}],
     ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
-                                      [uaa_jwt, signing_keys, #{<<"token-key">> => {map, Jwk}}]),
+                                      [rabbitmq_auth_backend_oauth2, uaa_jwt, UaaEnv]),
     ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
                                       [rabbitmq_auth_backend_oauth2, resource_server_id, ?RESOURCE_SERVER_ID]),
 
@@ -135,9 +136,7 @@ generate_expired_token(Config, Scopes) ->
 
 preconfigure_token(Config) ->
     Token = generate_valid_token(Config),
-
     rabbit_ct_helpers:set_config(Config, {fixture_jwt, Token}).
-
 
 %%
 %% Test Cases


### PR DESCRIPTION
In order for `uaa_jwt` settings to be populated into the environment by config files, they have to be part of a defined and running application. This PR adds support for a `uaa_jwt` sub-key of the main `rabbitmq_auth_backend_oauth2` env key.