### PR TITLE
Add protocol-specific context

### DIFF
--- a/src/rabbit_auth_backend_oauth2.erl
+++ b/src/rabbit_auth_backend_oauth2.erl
@@ -11,7 +11,7 @@
 %% The Original Code is RabbitMQ HTTP authentication.
 %%
 %% The Initial Developer of the Original Code is VMware, Inc.
-%% Copyright (c) 2007-2018 Pivotal Software, Inc.  All rights reserved.
+%% Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 %%
 
 -module(rabbit_auth_backend_oauth2).
@@ -23,7 +23,7 @@
 
 -export([description/0]).
 -export([user_login_authentication/2, user_login_authorization/2,
-         check_vhost_access/3, check_resource_access/3,
+         check_vhost_access/3, check_resource_access/4,
          check_topic_access/4]).
 
 -import(rabbit_data_coercion, [to_map/1]).
@@ -62,7 +62,7 @@ user_login_authorization(Username, AuthProps) ->
     end.
 
 check_vhost_access(#auth_user{impl = DecodedToken},
-                   VHost, _Sock) ->
+                   VHost, _AuthzData) ->
     with_decoded_token(DecodedToken,
         fun() ->
             Scopes      = get_scopes(DecodedToken),
@@ -72,7 +72,7 @@ check_vhost_access(#auth_user{impl = DecodedToken},
         end).
 
 check_resource_access(#auth_user{impl = DecodedToken},
-                      Resource, Permission) ->
+                      Resource, Permission, _AuthzContext) ->
     with_decoded_token(DecodedToken,
         fun() ->
             Scopes = get_scopes(DecodedToken),

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -65,20 +65,23 @@ test_successful_access_with_a_token(_) ->
              #resource{virtual_host = <<"vhost">>,
                        kind = queue,
                        name = <<"foo">>},
-             configure)),
+             configure,
+             #{})),
     ?assertEqual(true, rabbit_auth_backend_oauth2:check_resource_access(
                          User,
                          #resource{virtual_host = <<"vhost">>,
                                    kind = exchange,
                                    name = <<"foo">>},
-                         write)),
+                         write,
+                         #{})),
 
     ?assertEqual(true, rabbit_auth_backend_oauth2:check_resource_access(
                          User,
                          #resource{virtual_host = <<"vhost">>,
                                    kind = custom,
                                    name = <<"bar">>},
-                         read)),
+                         read,
+                         #{})),
 
     ?assertEqual(true, rabbit_auth_backend_oauth2:check_topic_access(
                          User,
@@ -146,13 +149,15 @@ test_insufficient_permissions_in_a_valid_token(_) ->
                           #resource{virtual_host = <<"vhost">>,
                                     kind = queue,
                                     name = <<"foo1">>},
-                          configure)),
+                          configure,
+                          #{})),
     ?assertEqual(false, rabbit_auth_backend_oauth2:check_resource_access(
                           User,
                           #resource{virtual_host = <<"vhost">>,
                                     kind = custom,
                                     name = <<"bar">>},
-                          write)),
+                          write,
+                          #{})),
     ?assertEqual(false, rabbit_auth_backend_oauth2:check_topic_access(
                           User,
                           #resource{virtual_host = <<"vhost">>,


### PR DESCRIPTION
Just an update of check_resource_access/3 to check_resource_access/4,
the OAuth has no use of protocol-specific data for now.

References rabbitmq/rabbitmq-server#1767