### PR TITLE
uaa_jwt:get_jwk/1: return an error if there are no configured signing keys

### DIFF
--- a/src/uaa_jwt.erl
+++ b/src/uaa_jwt.erl
@@ -61,18 +61,21 @@ decode_and_verify(Token) ->
 
 -spec get_jwk(binary()) -> {ok, map()} | {error, term()}.
 get_jwk(KeyId) ->
-    Keys = signing_keys(),
-    case maps:get(KeyId, Keys, undefined) of
-        undefined ->
-            {error, key_not_found};
-        {Type, Value} ->
-            case Type of
-                json     -> uaa_jwt_jwk:make_jwk(Value);
-                pem      -> uaa_jwt_jwk:from_pem(Value);
-                pem_file -> uaa_jwt_jwk:from_pem_file(Value);
-                map      -> uaa_jwt_jwk:make_jwk(Value);
-                _        -> {error, unknown_signing_key_type}
-            end
+    case signing_keys() of
+      undefined -> {error, signing_keys_not_configured};
+      Keys      ->
+        case maps:get(KeyId, Keys, undefined) of
+            undefined ->
+                {error, key_not_found};
+            {Type, Value} ->
+                case Type of
+                    json     -> uaa_jwt_jwk:make_jwk(Value);
+                    pem      -> uaa_jwt_jwk:from_pem(Value);
+                    pem_file -> uaa_jwt_jwk:from_pem_file(Value);
+                    map      -> uaa_jwt_jwk:make_jwk(Value);
+                    _        -> {error, unknown_signing_key_type}
+                end
+        end
     end.
 
 verify_signing_key(Type, Value) ->


### PR DESCRIPTION
Closes #30.