### PR TITLE
Support for gathering scopes from predefined JWT section

### DIFF
--- a/src/rabbit_auth_backend_oauth2.erl
+++ b/src/rabbit_auth_backend_oauth2.erl
@@ -38,7 +38,7 @@
 
 -define(APP, rabbitmq_auth_backend_oauth2).
 -define(RESOURCE_SERVER_ID, resource_server_id).
--define(COMPLEX_CLAIM, extra_permissions_source).
+-define(COMPLEX_CLAIM, extra_scopes_source).
 
 description() ->
     [{name, <<"UAA">>},
@@ -194,19 +194,19 @@ post_process_payload_complex_claim(Payload) ->
                 case maps:get(ResourceServerId, Content, empty) of
                     empty ->
                         [];
-                    Permissions when is_list(Permissions) ->
-                        case Permissions of
+                    ExtraScopes when is_list(ExtraScopes) ->
+                        case ExtraScopes of
                             [] ->
                                 [];
                             _ ->
-                                [erlang:iolist_to_binary([ResourceServerId, <<".">>, K]) || K <- Permissions]
+                                [erlang:iolist_to_binary([ResourceServerId, <<".">>, K]) || K <- ExtraScopes]
                             end;
-                    Permission when is_binary(Permission) ->
-                        case Permission of
+                    ExtraScopes when is_binary(ExtraScopes) ->
+                        case ExtraScopes of
                             <<>> ->
                                 [];
                             _ ->
-                                RawClaims = binary:split(Permission, <<" ">>, [global]),
+                                RawClaims = binary:split(ExtraScopes, <<" ">>, [global]),
                                 [erlang:iolist_to_binary([ResourceServerId, <<".">>, K]) || K <- RawClaims]
                             end;
                     _ -> 
@@ -232,7 +232,7 @@ post_process_payload_complex_claim(Payload) ->
                 [] ->
                     maps:put(<<"scope">>, Scopes, Payload);
                 _ ->                            
-                    maps:put(<<"scope">>, [TokenScopes, Scopes], Payload)
+                    maps:put(<<"scope">>, Scopes ++ TokenScopes, Payload)
             end
         end.
 
@@ -253,7 +253,7 @@ post_process_payload_keycloak(#{<<"authorization">> := Authorization} = Payload)
                 [] ->
                     maps:put(<<"scope">>, Scopes, Payload);
                 _ ->                            
-                    maps:put(<<"scope">>, [TokenScopes, Scopes], Payload)
+                    maps:put(<<"scope">>, Scopes ++ TokenScopes, Payload)
             end
     end.
 

--- a/test/system_SUITE.erl
+++ b/test/system_SUITE.erl
@@ -61,7 +61,7 @@ groups() ->
 
 -define(UTIL_MOD, rabbit_auth_backend_oauth2_test_util).
 -define(RESOURCE_SERVER_ID, <<"rabbitmq">>).
--define(EXTRA_PERMISSION_SOURCE, <<"rabbit_resources">>).
+-define(EXTRA_SCOPES_SOURCE, <<"rabbit_resources">>).
 
 init_per_suite(Config) ->
     rabbit_ct_helpers:log_environment(),
@@ -129,7 +129,7 @@ preconfigure_node(Config) ->
     ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
                                       [rabbitmq_auth_backend_oauth2, resource_server_id, ?RESOURCE_SERVER_ID]),
     ok = rabbit_ct_broker_helpers:rpc(Config, 0, application, set_env,
-        [rabbitmq_auth_backend_oauth2, extra_permissions_source, ?EXTRA_PERMISSION_SOURCE]),
+        [rabbitmq_auth_backend_oauth2, extra_scopes_source, ?EXTRA_SCOPES_SOURCE]),
 
     rabbit_ct_helpers:set_config(Config, {fixture_jwk, Jwk}).
 
@@ -218,7 +218,7 @@ test_successful_connection_with_simple_strings_for_aud_and_scope(Config) ->
     close_connection_and_channel(Conn, Ch).
 
 test_successful_connection_with_map_complex_claim_token(Config) ->
-    application:set_env(rabbitmq_auth_backend_oauth2, extra_permissions_source, <<"rabbit_resources">>),
+    application:set_env(rabbitmq_auth_backend_oauth2, extra_scopes_source, <<"rabbit_resources">>),
     application:set_env(rabbitmq_auth_backend_oauth2, resource_server_id, <<"rabbitmq">>),
     {_Algo, Token} = generate_valid_token_with_extra_fields(
         Config,
@@ -231,7 +231,7 @@ test_successful_connection_with_map_complex_claim_token(Config) ->
     close_connection_and_channel(Conn, Ch).
 
 test_successful_connection_with_list_complex_claim_token(Config) ->
-    application:set_env(rabbitmq_auth_backend_oauth2, extra_permissions_source, <<"rabbit_resources">>),
+    application:set_env(rabbitmq_auth_backend_oauth2, extra_scopes_source, <<"rabbit_resources">>),
     application:set_env(rabbitmq_auth_backend_oauth2, resource_server_id, <<"rabbitmq">>),
     {_Algo, Token} = generate_valid_token_with_extra_fields(
         Config,
@@ -244,7 +244,7 @@ test_successful_connection_with_list_complex_claim_token(Config) ->
     close_connection_and_channel(Conn, Ch).
         
 test_successful_connection_with_binary_complex_claim_token(Config) ->
-    application:set_env(rabbitmq_auth_backend_oauth2, extra_permissions_source, <<"rabbit_resources">>),
+    application:set_env(rabbitmq_auth_backend_oauth2, extra_scopes_source, <<"rabbit_resources">>),
     application:set_env(rabbitmq_auth_backend_oauth2, resource_server_id, <<"rabbitmq">>),
     {_Algo, Token} = generate_valid_token_with_extra_fields(
         Config,

--- a/test/unit_SUITE.erl
+++ b/test/unit_SUITE.erl
@@ -184,7 +184,7 @@ test_post_process_token_payload_complex_claims(_) ->
         end, AuthorizationArgumentExpectedScope).
 
 post_process_payload_with_complex_claim_authorization(Authorization) ->
-    application:set_env(rabbitmq_auth_backend_oauth2, extra_permissions_source, <<"rabbit_resources">>),
+    application:set_env(rabbitmq_auth_backend_oauth2, extra_scopes_source, <<"rabbit_resources">>),
     application:set_env(rabbitmq_auth_backend_oauth2, resource_server_id, <<"rabbitmq">>),
     Jwk = ?UTIL_MOD:fixture_jwk(),
     Token =  maps:put(<<"rabbit_resources">>, Authorization, ?UTIL_MOD:fixture_token_with_scopes([])),


### PR DESCRIPTION
## Proposed Changes

Please consider to add support to gather aditional source of _scopes_ form JWT token and combine them with existing ones. In RabbitMq configuration file would be defined one more option with JWT section name. Scopes comming from that section would be combined with values from "_scope_" section in _post_process_payload()_ method. Further calculations of access and permissions would be untouched.

I know that something similar was handled for Keycloak token, but I wanted to create another but more flexible solution. 

This solution works with when in advanced.config is set option "_extra_permissions_source_". This value tells in which JWT section pluggin should looks for additional scopes. In prepared solution I handled different data types which can be stored in that section. Let's assume "extra_permissions_source" is set to "rabbit_resources" and "_resource_server_id_" is set to "_rabbitmq_", so examined section can constains data like:

- binary (in this case scopes should have included "resource_server_id" prefix):
```
"rabbit_resources": 
    "rabbitmq.read:*/* rabbitmq.confiugre:*/* rabbitmq.tag:monitoring"
```

- list (in this case scopes should have included "resource_server_id" prefix):
```
"rabbit_resources": [
       "rabbitmq.write:*/*", 
      "rabbitmq.confiugre:*/*", 
      "tag:administrator"
]
```

- map (this is the most comples case - in this case each key is unique "_resource_server_id_" and proper content is get by "_resource_server_id_" defined in config file. Then, when type of content is a list - to each element is added map key as prefix. Here I also decided to handle different map content data types):
```
"rabbit_resources": {
   %% map with list content
   rabbitmq => [
          "write:*/*", "confiugre:*/*", "tag:administrator"],
   rabbitmq_2 => [
           "read:*/*", "confiugre:*/*", "tag:monitoring"],
  %% map with binary content
  rabbitmq_3 => "read:*/* confiugre:*/* tag:monitoring"
}
```
In our example output collection would be: 
`[<<"rabbitmq.write:*/*">>, <<"rabbitmq.confiugre:*/*">>, <<"rabbitmq.tag:administrator">>]`

To test this and get some accessToken you can use prepared for this purposes IdentityServer from this branch: [https://github.com/papugamichal/IdentityServer4.Demo](https://github.com/papugamichal/IdentityServer4.Demo). Readme.md cointains instruction how to get token with Postman.

Below I include example long living tokens:
- _rabbit_resources_ binary content:
`eyJhbGciOiJSUzI1NiIsImtpZCI6Ik9YTndkX1RMZGJJY09leDZiTExTdFEiLCJ0eXAiOiJhdCtqd3QifQ.eyJuYmYiOjE1NzU0ODI1NTQsImV4cCI6MTYwNzAzOTQ4MCwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwMCIsImF1ZCI6WyJodHRwOi8vbG9jYWxob3N0OjUwMDAwL3Jlc291cmNlcyIsInJhYmJpdG1xIl0sImNsaWVudF9pZCI6IkdpdEh1Yi5SYWJiaXRNcS5NYW5hZ2VtZW50V2Vic2l0ZS5Mb2NhbCIsInN1YiI6IjExMSIsImF1dGhfdGltZSI6MTU3NTQ4MjM1MCwiaWRwIjoibG9jYWwiLCJyb2xlIjoiUmVhZE9ubHlVc2VyIiwicmFiYml0X3Jlc291cmNlcyI6InJhYmJpdG1xLnJlYWQ6Ki8qIHJhYmJpdG1xLmNvbmZpZ3VyZToqLyogcmFiYml0bXEudGFnOm1vbml0b3JpbmciLCJzY29wZSI6WyJyYWJiaXRtcS5tYW5hZ2VtZW50d2Vic2l0ZSJdLCJhbXIiOlsicHdkIl19.grufCee_krpFfVy2clRXmUUFyi2QOcgiQTENWmRWlro2j05ix0QGulHSP4d2aN-yf7WqS7LzXXjXT0GGKgAT3t65jqdH9TdPx_ztyWuUIMvfcMjfMuhNTE-QtOUIOFvVuYlPtvzPhuD1p9vCSMdBR_OHo4HWlh_qz50_B6Up0JcuRFlJ32y-93ctM7zqdyvEQGRzS4-80OK5OoSwokXu3dOMiTrXc2FASECk5TRnhhPehLauoHuzckcmQ_wiOXxQOTWGtrMgfGkxL4WXc3s6nuv-dC4Wf7Iew_2P1KHApPSk2IGvASs2fi902OEimXBxa2bhTK_LzfgmPtEY5q6iOA`

- __rabbit_resources__ list content:
`eyJhbGciOiJSUzI1NiIsImtpZCI6Ik9YTndkX1RMZGJJY09leDZiTExTdFEiLCJ0eXAiOiJhdCtqd3QifQ.eyJuYmYiOjE1NzU0ODI4MDQsImV4cCI6MTYwNzAzOTczMCwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwMCIsImF1ZCI6WyJodHRwOi8vbG9jYWxob3N0OjUwMDAwL3Jlc291cmNlcyIsInJhYmJpdG1xIl0sImNsaWVudF9pZCI6IkdpdEh1Yi5SYWJiaXRNcS5NYW5hZ2VtZW50V2Vic2l0ZS5Mb2NhbCIsInN1YiI6IjExIiwiYXV0aF90aW1lIjoxNTc1NDgyNzE1LCJpZHAiOiJsb2NhbCIsInJvbGUiOiJBZG1pbiIsInJhYmJpdF9yZXNvdXJjZXMiOlsicmFiYml0bXEuY29uZmlndXJlOiovKiIsInJhYmJpdG1xLnJlYWQ6Ki8qIiwicmFiYml0bXEudGFnLmFkbWluaXN0cmF0b3IiXSwic2NvcGUiOlsicmFiYml0bXEubWFuYWdlbWVudHdlYnNpdGUiXSwiYW1yIjpbInB3ZCJdfQ.VKmx-Pvmo5HXs441EqgHRwjzzWc6IbWXqJVvhC1cKQ9PubkffOeCIriKEcP1QGlhe_4-iY_wsvioZ2VHBYKa3qq5DQb0u61clBvcy-CK8raC8r2yctJrnpRmzYrjs2N2AOfEPpxSmePmlV9DzfhfpTPKHnUtjdlznFAzC2U9Iq2VhIkYP3kJCIcjQ9w_YyCkNwATqYA_LgyTW4TJth5G0VGs3LCan5UJUJ946NvwUyWYt6UutfM1zLIceOxf9FUbXq4Seq7ZznzEAZFwHcFArYCmQ-dKm8HIoxl382o1cFhs8gRd2IeVjRxi425ZL22LyOyRKvOC7svqkbP5VaHjPQ`

- _rabbit_resources_ map content (two lists and binary):
`eyJhbGciOiJSUzI1NiIsImtpZCI6Ik9YTndkX1RMZGJJY09leDZiTExTdFEiLCJ0eXAiOiJhdCtqd3QifQ.eyJuYmYiOjE1NzU0ODI2MjgsImV4cCI6MTYwNzAzOTU1NCwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwMCIsImF1ZCI6WyJodHRwOi8vbG9jYWxob3N0OjUwMDAwL3Jlc291cmNlcyIsInJhYmJpdG1xIl0sImNsaWVudF9pZCI6IkdpdEh1Yi5SYWJiaXRNcS5NYW5hZ2VtZW50V2Vic2l0ZS5Mb2NhbCIsInN1YiI6IjEiLCJhdXRoX3RpbWUiOjE1NzU0ODI2MjcsImlkcCI6ImxvY2FsIiwicm9sZSI6IlJlYWRPbmx5VXNlciIsInNjb3BlIjpbInJhYmJpdG1xLm1hbmFnZW1lbnR3ZWJzaXRlIl0sImFtciI6WyJwd2QiXSwicmFiYml0X3Jlc291cmNlcyI6eyJyYWJiaXRtcSI6WyJyZWFkOiovKiIsIndyaXRlOiovKiIsInRhZzphZG1pbmlzdHJhdG9yIl0sInJhYmJpdG1xMiI6WyJyZWFkOiovKiIsInRhZzptb25pdG9yaW5nIl0sInJhYmJpdG1xMyI6InJlYWQ6Ki8qIHRhZzpwb2xpY3lfbWFrZXIifX0.k3H5Zq51QeXeGBzUy6OXTbEXMJXrmIbw7wRW122gl91vPHqE0xT2xGem4yPEvODWTqYWsxOUOPrVEaRUUAWCAChwlAtrgb-TN9g17SPkDqMhVNmKnzL-BhVTBfZw0c7rAT-cwJ9UdKzuvP_xbMypTcM3IQcF6_AjqvwUeA_W30DHXpBUtF6lnuDSugNSYrNHMd222gBGe0_SlA_OX2aSs75VRkDJKsiIHLqX0TfJ2DU8KphTnaNLFmIMDsYR5bhGpbPhfpzeGU6OGdQUFP9_k6xzapI4qEcpzIW99oomLHkp73fnGHSVTqy-8NDVQM8xQFPeRnUBUOdtsq5oXrCsVA`

## Types of Changes

What types of changes does your code introduce to this project?
- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
