### PR TITLE
Add support for using extra scopes standalone

### DIFF
--- a/src/rabbit_auth_backend_oauth2.erl
+++ b/src/rabbit_auth_backend_oauth2.erl
@@ -199,11 +199,8 @@ post_process_payload_complex_claim(Payload) ->
     case AdditionalScopes of
         [] -> Payload;
         _  ->
-            TokenScopes = maps:get(<<"scope">>, Payload),
-            case TokenScopes of
-                [] -> maps:put(<<"scope">>, AdditionalScopes, Payload);
-                _  -> maps:put(<<"scope">>, AdditionalScopes ++ TokenScopes, Payload)
-            end
+            ExistingScopes = maps:get(<<"scope">>, Payload, []),
+            maps:put(<<"scope">>, AdditionalScopes ++ ExistingScopes, Payload)
         end.
 
 %% keycloak token format: https://github.com/rabbitmq/rabbitmq-auth-backend-oauth2/issues/36


### PR DESCRIPTION
## Proposed Changes

This PR makes it possible to use additional sources of scopes in a token
standalone, without the need of combining them with existing ones.

Using RBAC and tokens from Azure AD, `scope` is not part of the token but `roles` is. It is possible to configure `roles` as an additional scope with `extra_scopes_source` but that does not work completely because `maps:get(<<"scope">>, Payload)` in `post_process_payload_complex_claim` fail with `{badkey, <<"scope">>}` expecting `scope` to be present in the token. Changing from `maps:get(<<"scope">>, Payload)` to `maps:get(<<"scope">>, Payload, [])` solves this by returning an empty list if `scope` can't be found in the token.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories
